### PR TITLE
Fixed a linking issue on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CFLAGS=-g -O2 -Wall -DHAVE_READLINE -DHAVE_EDITLINE
-LDFLAGS=-g -ldl -lpthread -lreadline
+LDFLAGS=-g
+SYSTEM_LIBS=-ldl -lpthread -lreadline
 LIBOBJS0 = alter.lo analyze.lo attach.lo auth.lo \
          backup.lo bitvec.lo btmutex.lo btree.lo build.lo \
          callback.lo complete.lo ctime.lo \
@@ -29,4 +30,4 @@ clean:
 	$(CC) -c $(CFLAGS) $< -o $@
 
 sqlite: $(LIBOBJS0)
-	$(CC) $(LDFLAGS) $(LIBOBJS0) -o sqlite
+	$(CC) $(LDFLAGS) $(LIBOBJS0) $(SYSTEM_LIBS) -o sqlite


### PR DESCRIPTION
he out-of-project libraries were being passed _before_ the in-project object files to the linker. Since the linker (ld) processes objects and libraries from right to left, and only uses an object or library to resolve previously-discovered unresolved symbols - the linker fails to use these libraries to resolve the symbols used in the project objects. This is now avoided.

See [this StackOverflow](https://stackoverflow.com/q/45135/1593077) question for details.